### PR TITLE
chore(dependabot): disable dependabot for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-
-  - package-ecosystem: "pip"
-    directory: "/website-helper"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
This pull request disable dependabot for pip which is no longer used.